### PR TITLE
Add synopsis for Learn Elixir talk, 13 Feb 2017

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 
-		<meta name="keywords" content="functional programming, software engineering, manchester, north west, uk, england, madlab, clojure, haskell, erlang, F#, scala, lisp, ml, objective caml, o-caml, events, meetings, ">
+		<meta name="keywords" content="functional programming, software engineering, manchester, north west, uk, england, madlab, clojure, haskell, erlang, F#, scala, lisp, ml, objective caml, o-caml, elixir, events, meetings, ">
 		<meta name="description" content="The Manchester Lambda Lounge meet regularly to promote and support functional programming in the United Kingdom.">
 
 		<title>The Manchester Lambda Lounge</title>
@@ -234,39 +234,61 @@ impossible thoughts."</i><div><b>-&nbsp;Edsger Dijkstra</b><br></div><br>
 
 		<section data-behaviour="tabbed" id="jam_209" class="">
 			<div class="container" id="meetings" style="min-height: 690.5px;">
-				<div class="chunk event active" id="text-editor-data-structures" data-tabname="16 Jan 2017" style="display: none;">
+				<div class="chunk event active" id="learn-elixir" data-tabname="13 Feb 2017" style="display: none;">
 					<div class="content fullwidth column">
 						<div class="date">
-							<div class="month">Jan</div>
-							<div class="day">16</div>
+							<div class="month">Feb</div>
+							<div class="day">13</div>
 						</div>
 						<div>
-						This month <span><a href="https://twitter.com/osfameron">Hakim Cassimally</a> is presenting on <b>Data Structures for Text Editors</b>.
-						&nbsp; We're meeting on Monday 16th Jan in <b>madlab</b> at the
-						normal time of <b>7pm</b>.
-						<br>
-						To support the features that we need as programmers, <b>text
-						editors</b> arrange textual data in rather different ways than
-						we might expect from other text-processing tasks, where we
-						commonly use strings and streams of characters.
-						<br>
-						We'll first look at some classic text editor
-						data-structures like <b>Lists of lines</b> (vi, Atom), the
-						<b>Gap Buffer</b> (Emacs), and then at purely functional
-						data structures that fit better with functional languages -
-						structures like <b>Piece Tables</b> (Abiword, Bravo), various
-						sorts of tree (the infamous Xanadu, GtkTextBuffer) and
-						<b>Zippers</b> (yi).
-						<br>
-						I'll be showing a few examples in <b>Clojure</b>, but the
-						approaches are valuable in any language (I've done previous
-						prototypes in <b>Perl</b>, <b>Java</b>, and
-						<b>Haskell</b>!)
-
-						<br>
+							We're meeting on Monday 13th Feb at 7pm at <b>madlab</b> to learn Elixir!
+							<br>
+							<strong>Elixir</strong> is a dynamic, functional language with Ruby-like syntax that runs on the Erlang virtual machine.
+							With first class support for <strong>concurrency, scalability, fault tolerance</strong> and <strong>high availability</strong>,
+							all courtesy of its Erlang roots, it can be described as the language for today's real time, hyper-connected world.
+							<br><br>
+							In this short introduction to Elixir presented by <a href="https://twitter.com/thisischichi">Chi-chi Ekweozor</a>,
+							learn how to use the ubiquitous <strong>pipeline operator |> </strong> to consume functions as data,
+							<strong>pattern matching, modules, lists</strong> and other language constructs.
+							Level up and get writing distributed software applications that go beyond the browser on to mobile and the Internet of Things.
+							<br>
 						</div>
 					</div>
-					</div>
+				 </div>
+
+				 <div class="chunk event active" id="text-editor-data-structures2" data-tabname="16 Jan 2017" style="display: none;">
+ 					<div class="content fullwidth column">
+ 						<div class="date">
+ 							<div class="month">Jan</div>
+ 							<div class="day">16</div>
+ 						</div>
+ 						<div>
+ 						This month <span><a href="https://twitter.com/osfameron">Hakim Cassimally</a> is presenting on <b>Data Structures for Text Editors</b>.
+ 						&nbsp; We're meeting on Monday 16th Jan in <b>madlab</b> at the
+ 						normal time of <b>7pm</b>.
+ 						<br>
+ 						To support the features that we need as programmers, <b>text
+ 						editors</b> arrange textual data in rather different ways than
+ 						we might expect from other text-processing tasks, where we
+ 						commonly use strings and streams of characters.
+ 						<br>
+ 						We'll first look at some classic text editor
+ 						data-structures like <b>Lists of lines</b> (vi, Atom), the
+ 						<b>Gap Buffer</b> (Emacs), and then at purely functional
+ 						data structures that fit better with functional languages -
+ 						structures like <b>Piece Tables</b> (Abiword, Bravo), various
+ 						sorts of tree (the infamous Xanadu, GtkTextBuffer) and
+ 						<b>Zippers</b> (yi).
+ 						<br>
+ 						I'll be showing a few examples in <b>Clojure</b>, but the
+ 						approaches are valuable in any language (I've done previous
+ 						prototypes in <b>Perl</b>, <b>Java</b>, and
+ 						<b>Haskell</b>!)
+
+ 						<br>
+ 						</div>
+ 					</div>
+ 				 </div>
 
 					<div class="chunk event active" id="elixir" data-tabname="17 Oct">
 						<div class="content fullwidth column">


### PR DESCRIPTION
Added: 
- Synopsis for Learn Elixir talk, 13 Feb 2017
- Elixir to list of languages highlighted in meta keywords tag